### PR TITLE
An implementation for substitution of latex with regexs.

### DIFF
--- a/roboph.py
+++ b/roboph.py
@@ -7,7 +7,7 @@ import subprocess
 from AppKit import NSSpeechSynthesizer, NSURL
 import xml.etree.ElementTree as ElementTree
 from bs4 import BeautifulSoup
-from substitutions.py import regex_substitute
+from substitutions import regex_substitute
 
 VALID_VOICES = [str(x.replace('com.apple.speech.synthesis.voice.', '')) for x in NSSpeechSynthesizer.availableVoices()]
 VOICES =['lee.premium', 'fiona.premium', 'emily.premium', 'Alex', 'tom.premium', 'jill.premium', 'sangeeta.premium']

--- a/roboph.py
+++ b/roboph.py
@@ -7,6 +7,7 @@ import subprocess
 from AppKit import NSSpeechSynthesizer, NSURL
 import xml.etree.ElementTree as ElementTree
 from bs4 import BeautifulSoup
+from substitutions.py import regex_substitute
 
 VALID_VOICES = [str(x.replace('com.apple.speech.synthesis.voice.', '')) for x in NSSpeechSynthesizer.availableVoices()]
 VOICES =['lee.premium', 'fiona.premium', 'emily.premium', 'Alex', 'tom.premium', 'jill.premium', 'sangeeta.premium']
@@ -84,8 +85,8 @@ def get_latest_articles():
         # Parse main text
         article.text = BeautifulSoup(article_xml.find('{http://purl.org/rss/1.0/}description').text, "html.parser").getText().strip()
 
-        # Remove dollar signs
-        article.text = article.text.replace('$', '')
+        # Substitute/replace using regular expressions
+        article.text = regex_substitute(article.text)
 
         articles.append(article)
 

--- a/substitutions.py
+++ b/substitutions.py
@@ -144,6 +144,7 @@ def substitution_lists():
     other = [(r"([A-Za-z]+)\-\-([A-Za-z]+)", r" \g<1>-\g<2>"), \
              (r"(\d+) ?\-\- ?(\d+)", r"\g<1> to \g<2>"), \
              (r"\$?(\w+)_{(.+?)}\$?", r"\g<1> sub \g<2>"), \
+             (r"(\d{1,3}) (\d{3})", r"\g<1>,\g<2>"), \
              ] 
     
     # Can either ignore (remove) accent or 

--- a/substitutions.py
+++ b/substitutions.py
@@ -1,0 +1,165 @@
+""" Regexp processing of latex commands to words for tts.
+These lists need adding to as more abstracts are scanned"""
+
+import re
+
+def cat_lists(*list_args):
+    """ Given any number of lists, concatinate into a single list """
+    result = []
+    for List in list_args:
+        result.extend(List)
+
+    return result
+
+def regex_substitute(text):
+    """ Subsitute latex commands for words """
+    substitutions = substitution_lists()
+    
+    for sub in substitutions:
+        pattern = sub[0]
+        replacement = sub[1] 
+
+        text = re.sub(pattern, replacement, text)
+
+    return text
+
+def substitution_lists(): 
+    """ Regex for latex replacement.
+    Lists of (pattern, replacement) tuples are used to store the regex 
+    to preserve implementation order (unlike dict).
+    Stored in .py file to treat all as raw strings. r' ' 
+     
+    """
+      
+    space = [(r"\\\,", " "), \
+                 (r"\~", " "), \
+                 ]
+   
+    font_formats = [(r"\\rm ?", r""), \
+                    (r"\\mathrm ?", r""), \
+                    (r"\\textbf{(.*?)}", r" \g<1> "), \
+                    (r"\\textit{(.*?)}", r" \g<1> "), \
+                    (r"\\emph{(.*?)}", r" \g<1> "), \
+                    (r"\\small ?", r""), \
+                    ]    
+    
+    astro = [(r"H\(?i\)?","H1 "), \
+             (r"H\(?ii\)?","H2 "), \
+             (r"\\arcsec ?","arcseconds "), \
+             ]
+
+    powers = [(r"m( |\\,)?s\$\^{-1}\$", r" meters per second "), \
+              (r"( |\\,)s\$\^{-1}\$", r" per second "), \
+    		  (r"( |\\,)s\$\^{-2}\$", r" per second squared "), \
+    		  (r" ([A-Za-z]+ ?)\$?\^{-2}\$?", r" per \g<1> squared "), \
+    		  (r" ?\^\{2\}\$?", r" squared"), \
+   			  (r" ?\^\{3\}\$?", r" cubed"), \
+    	 	  (r"\$?(\d+) ?\^{?\-(\d+)}?\$?", 
+                r"\g<1> to the power of negative \g<2>"), \
+              (r"\$?(\d+) ?\^{?(\d+)}?\$?", r" \g<1> to the power of \g<2> "),\
+              (r"\$\^{?(\d+)}?\$", r" to the power of \g<1> "), \
+    		  ]        
+
+    symbols = [(r"\\hbar", " hbar "), \
+                (r"\\nabla", " nabla "), \
+                (r"\\infty", " infinity "), \
+                (r"\$?\\sim\$?", " is of order of "), \
+                (r"\\propto", r" proportional to "), \
+                (r"\\neq", r" not equal to "), \
+                (r"\\geq", r" greater than or equal to "), \
+                (r"\\leq", r" less than or equal to "), \
+                (r"\\equiv", r" equivalent to "), \
+                (r"\\approx", r" approximately "), \
+                (r"\\simeq", r" approximately equal to "), \
+                (r" ?\> ?", r" greater than "), \
+                (r" ?\< ?", r" less than "), \
+                (r"\\times", r" times "), \
+                (r"\\pm", r" plus minus "), \
+                (r"\\mp", r" minus plus "), \
+                (r"\\%", r" percent "), \
+                (r"\\dot{(\w*)}", r" \g<1> dot "), \
+                ]
+
+    trig = [(r"\\sin", " sine ", r"\\cos", " cosine "), \
+            (r"\\arcsin", " arc sine "), \
+            (r"\\arccos", " arc cosine "), \
+            ]
+
+    greek = [(r"\\aplha", r" aplha "), \
+             (r"\\[b]eta", r" beta "), \
+             (r"\\[Gg]amma", r" gamma "), \
+             (r"\\[Dd]elta", r" delta "), \
+             (r"\\[var]?epsilon", r" epsilon "), \
+             (r"\\zeta", r" zeta "), \
+             (r"\\eta", r" eta "), \
+             (r"\\[var]?[Tt]heta", r" theta "), \
+             (r"\\iota", r" iota "), \
+             (r"\\[var]?kappa", r" kappa "), \
+             (r"\\[Ll]ambda", r" lambda "), \
+             (r"\\mu", r" mu "), \
+             (r"\\nu", r" nu "), \
+             (r"\\[Xx]i", r" xi "), \
+             (r"\\[var]?[Pp]i", r" pi "), \
+             (r"\\[var]?rho", r" rho "), \
+             (r"\\[var]?[Ss]igma", r" sigma "), \
+             (r"\\tau", r" tau "), \
+             (r"\\[Uu]psilon", r" upsilon "), \
+             (r"\\[var]?[Pp]hi", r" phi "), \
+             (r"\\chi", r" chi "), \
+             (r"\\[Pp]si", r" psi "), \
+             ]
+
+    solarsys = [(r"M ?\$?\_{?\\oplus}?\$?", r" Earth masses "), \
+               (r"M ?\$?\_{?\\odot}?\$?", r" Solar masses "), \
+               (r"M ?\$?\_{?\\star}?\$?", r" Stellar masses "), \
+               (r"R ?\$?\_{?\\oplus}?\$?", r" Earth radii "), \
+               (r"R ?\$?\_{?\\odot}?\$?", r" Solar radii "), \
+               (r"R ?\$?\_{?\\star}?\$?", r" Stellar radii "), \
+               (r"\$?M\$?\_{Jup}\$?", r" Jupiter masses "), \
+               (r"R\$?\_{Jup}\$?", r" Jupiter radii "), \
+               (r"AU", r"AU"), \
+               (r"[^MR]\_\\oplus", r" Earth "), \
+               (r"[^MR]\_\\odot", r" Sun "), \
+               (r"[^MR]\_\\star", r" Star "), \
+               ]
+
+    units = [(r"( .*[^A-Za-z])pc[^A-Za-z]", r"\g<1> parsec "), \
+            (r"[^A-Za-z]\\?mu ?m[^A-Za-z] ?", r" micrometers "), \
+            (r"( .*[^A-Za-z])km[^A-Za-z]", r" kilometers "), \
+            (r"( .*[^A-Za-z])nm[^A-Za-z]", r"\g<1> nanometers "), \
+            (r"( |\\,)cm[^A-Za-z]", r"\g<1> centimeters "), \
+            (r"(\d+)( |\\,)m[^A-Za-z]", r"\g<1> meters "), \
+            (r"( .*[^A-Za-z])Hz[^A-Za-z]", r"\g<1> Hertz "), \
+            (r" ?\\AA ?", r" Angstroms "), \
+            (r" ?Myr ?", r" Mega years "), \
+            (r'(\d+)\"(.?\,? )', r"\g<1> arcsecond\g<2>"), \
+            ]
+         
+    abrev = [(r" ?SNR ?", r" Signal to noise ratio "), \
+             (r" ?S/N ?", r" Signal to noise "), \
+             (r" ?Fig\. ?", r" Figure "), \
+             (r" ?Eq\. ?", r" Equation "), \
+             ] 
+
+    other = [(r"([A-Za-z]+)\-\-([A-Za-z]+)", r" \g<1>-\g<2>"), \
+             (r"(\d+) ?\-\- ?(\d+)", r"\g<1> to \g<2>"), \
+             (r"\$?(\w+)_{(.+?)}\$?", r"\g<1> sub \g<2>"), \
+             ] 
+    
+    # Can either ignore (remove) accent or 
+    # make actual accented letter if tts can handle them...
+    # e.g. \'{e}chelle  (r"\\\'{(\w)}", r"\g<1>")?
+    accents = []  
+
+    clean = [(r"\$", r""), \
+            (r" +", r" "), \
+            (r"{", r""), \
+            (r"}", r""), \
+            ] 
+
+	# Join regex into single list. Need to be careful of ordering.
+    regexs = cat_lists(space, font_formats, astro, powers, symbols, trig, 
+                        greek, solarsys, units, abrev, other, accents,
+                        clean)  
+   
+    return regexs


### PR DESCRIPTION
Hi there,

I have implemented a way for substitution of the pesky latex commands with regular expressions.
I am using similar method for my own project with the aim of tts for entire arXiv articles (hence the large regex collection).

Please let me know if there is other substitutions you want added/removed. More will need to be added in the future as things I haven't yet caught are found.

You will need to check that this actually works with roboph as I am unable to run the main scripts due to apple exclusive features. 

Enjoy
Jason
